### PR TITLE
Fixes to unblock storage team

### DIFF
--- a/src/csharp/lowlevel-generator/support/enum.ts
+++ b/src/csharp/lowlevel-generator/support/enum.ts
@@ -56,7 +56,7 @@ export class EnumClass extends Struct implements EnhancedTypeDeclaration {
 
   constructor(schemaWithFeatures: EnumImplementation, state: State, objectInitializer?: Partial<EnumClass>) {
     if (!schemaWithFeatures.schema.details.csharp.enum) {
-      throw new Error('ENUM AINT XMSENUM');
+      throw new Error(`ENUM AINT XMSENUM: ${schemaWithFeatures.schema.details.default.name}`);
     }
 
     super(state.project.supportNamespace, schemaWithFeatures.schema.details.csharp.enum.name, undefined, {

--- a/src/remodeler/main.ts
+++ b/src/remodeler/main.ts
@@ -17,7 +17,8 @@ export async function process(service: Host) {
 
     const original = await service.ReadFile(files[0]);
 
-    writeFileSync("C:/work/2018/autorest.incubator/generated/original.yaml", serialize(JSON.parse(original)));
+    // TODO: don't use a hard-coded path
+    // writeFileSync("C:/work/2018/autorest.incubator/generated/original.yaml", serialize(JSON.parse(original)));
 
     // deserialize
     const remodeler = new Remodeler(new ModelState(service, await deserialize<OpenAPI.Model>(await service.ReadFile(files[0]), files[0]), files[0]));


### PR DESCRIPTION
Comment out writing original yaml file to hard-coded directory.
Include the type name for 'ENUM AINT XMSENUM' failures.