### PR TITLE
First round of major codegen fixes

### DIFF
--- a/src/common/code-model/schema.ts
+++ b/src/common/code-model/schema.ts
@@ -72,11 +72,13 @@ export interface Property extends Extensions {
 }
 
 export class Property extends Extensions implements Property {
+  public serializedName: string;
   public details: LanguageDetails<PropertyDetails>;
   public extensions = new Dictionary<any>();
 
   constructor(name: string, initializer?: Partial<Property>) {
     super();
+    this.serializedName = name;
     this.details = {
       default: {
         description: 'MISSING DESCRIPTION 03',

--- a/src/csharp/code-dom/statements/if.ts
+++ b/src/csharp/code-dom/statements/if.ts
@@ -13,7 +13,7 @@ export class IfStatement extends Statements {
   }
   public get implementation(): string {
     return `
-if(${valueOf(this.conditional)})
+if (${valueOf(this.conditional)})
 {
 ${indent(super.implementation)}
 }`.trim();
@@ -34,7 +34,7 @@ export class WhileStatement extends Statements {
   }
   public get implementation(): string {
     return `
-while(${this.conditional.value})
+while (${this.conditional.value})
 {
 ${indent(super.implementation)}
 }`.trim();
@@ -50,7 +50,7 @@ export class ElseIfStatement extends Statements {
   }
   public get implementation(): string {
     return `
-else if(${this.conditional.value})
+else if (${this.conditional.value})
 {
 ${indent(super.implementation)}
 }`.trim();

--- a/src/csharp/code-dom/statements/switch.ts
+++ b/src/csharp/code-dom/statements/switch.ts
@@ -15,7 +15,7 @@ export class SwitchStatement extends Initializer implements Statement {
 
   public get implementation(): string {
     return `
-switch( ${this.expression.value} )
+switch ( ${this.expression.value} )
 {
 ${indent(this.caseStatements.map(each => each.implementation).join(EOL))}
 }`;

--- a/src/csharp/schema/array.ts
+++ b/src/csharp/schema/array.ts
@@ -116,6 +116,7 @@ export class ArrayOf implements EnhancedTypeDeclaration {
         }
         case KnownMediaType.Cookie:
         case KnownMediaType.QueryParameter:
+          return toExpression(`if (${value} != null && ${value}.Length > 0) { queryParameters.Add("${value}=" + System.Uri.EscapeDataString(System.Linq.Enumerable.Aggregate(${value}, (current, each) => current + "," + (string.IsNullOrEmpty(each) ? System.Uri.EscapeDataString(each) : System.String.Empty)))); }`)
         case KnownMediaType.Header:
         case KnownMediaType.Text:
         case KnownMediaType.UriParameter:

--- a/src/csharp/schema/date-time.ts
+++ b/src/csharp/schema/date-time.ts
@@ -13,7 +13,7 @@ export class DateTime extends Primitive {
   public isXmlAttribute: boolean = false;
   public jsonType = ClientRuntime.JsonString;
   // public DateFormat = new StringExpression('yyyy-MM-dd');
-  public DateTimeFormat = new StringExpression('yyyy\'-\'MM\'-\'dd\'T\'HH\':\'mm\':\'ss.FFFFFFFK');
+  public DateTimeFormat = new StringExpression('yyyy\'-\'MM\'-\'dd\'T\'HH\':\'mm\':\'ss.fffffffK');
 
 
   get declaration(): string {
@@ -29,13 +29,13 @@ export class DateTime extends Primitive {
     switch (mediaType) {
       case KnownMediaType.Json:
         return this.isRequired ?
-          toExpression(`(${ClientRuntime.JsonNode}) new ${this.jsonType}(${value}.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture))`) :
-          toExpression(`null != ${value} ? (${ClientRuntime.JsonNode}) new ${this.jsonType}(${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture)) : null`);
+          toExpression(`(${ClientRuntime.JsonNode}) new ${this.jsonType}(${value}.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture))`) :
+          toExpression(`null != ${value} ? (${ClientRuntime.JsonNode}) new ${this.jsonType}(${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture)) : null`);
 
       case KnownMediaType.Xml:
         return this.isRequired ?
-          toExpression(`new ${System.Xml.Linq.XElement}("${serializedName}",${value}.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture))`) :
-          toExpression(`null != ${value} ? new ${System.Xml.Linq.XElement}("${serializedName}",${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture)) : null`);
+          toExpression(`new ${System.Xml.Linq.XElement}("${serializedName}",${value}.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture))`) :
+          toExpression(`null != ${value} ? new ${System.Xml.Linq.XElement}("${serializedName}",${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture)) : null`);
 
       case KnownMediaType.Cookie:
       case KnownMediaType.QueryParameter:
@@ -43,8 +43,8 @@ export class DateTime extends Primitive {
       case KnownMediaType.Text:
       case KnownMediaType.UriParameter:
         return toExpression(this.isRequired ?
-          `${value}.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture)` :
-          `null == ${value} ? ${System.String.Empty} : "${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture)"`
+          `${value}.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture)` :
+          `null == ${value} ? ${System.String.Empty} : "${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture)"`
         );
     }
     return toExpression(`null /* serializeToNode doesn't support '${mediaType}' ${__filename}*/`);
@@ -62,20 +62,20 @@ export class DateTime extends Primitive {
       case KnownMediaType.Header:
         // container : HttpRequestHeaders
         return this.isRequired ?
-          `${valueOf(container)}.Add("${serializedName}",${value}.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture));` :
-          If(`null != ${value}`, `${valueOf(container)}.Add("${serializedName}",${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture));`);
+          `${valueOf(container)}.Add("${serializedName}",${value}.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture));` :
+          If(`null != ${value}`, `${valueOf(container)}.Add("${serializedName}",${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture));`);
 
       case KnownMediaType.QueryParameter:
         // gives a name=value for use inside a c# template string($"foo{someProperty}") as a query parameter
         return this.isRequired ?
-          `${serializedName}={${value}..ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture)}` :
-          `{null == ${value} ? ${System.String.Empty} : $"${serializedName}={${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture)}"}`;
+          `${serializedName}={${value}..ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture)}` :
+          `{null == ${value} ? ${System.String.Empty} : $"${serializedName}={${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture)}"}`;
 
       case KnownMediaType.UriParameter:
         // gives a name=value for use inside a c# template string($"foo{someProperty}") as a query parameter
         return this.isRequired ?
-          `${serializedName}={${value}.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture)}` :
-          `{null == ${value} ? "": $"${serializedName}={${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.CurrentCulture)}"}`;
+          `${serializedName}={${value}.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture)}` :
+          `{null == ${value} ? "": $"${serializedName}={${value}?.ToString(${this.DateTimeFormat},System.Globalization.CultureInfo.InvariantCulture)}"}`;
     }
     return (`/* serializeToContainerMember doesn't support '${mediaType}' ${__filename}*/`);
   }
@@ -85,9 +85,9 @@ export class DateTime extends Primitive {
   // public static string DateFormat = "yyyy-MM-dd";
   // public static string DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK";
   // public static string DateTimeRfc1123Format = "R";
-  // public static JsonString CreateDate(DateTime? value) => value is DateTime date ? new JsonString(date.ToString(DateFormat, CultureInfo.CurrentCulture)) : null;
-  // public static JsonString CreateDateTime(DateTime? value) => value is DateTime date ? new JsonString(date.ToString(DateTimeFormat, CultureInfo.CurrentCulture)) : null;
-  // public static JsonString CreateDateTimeRfc1123(DateTime ? value) => value is DateTime date ? new JsonString(date.ToString(DateTimeRfc1123Format, CultureInfo.CurrentCulture)) : null;
+  // public static JsonString CreateDate(DateTime? value) => value is DateTime date ? new JsonString(date.ToString(DateFormat, CultureInfo.InvariantCulture)) : null;
+  // public static JsonString CreateDateTime(DateTime? value) => value is DateTime date ? new JsonString(date.ToString(DateTimeFormat, CultureInfo.InvariantCulture)) : null;
+  // public static JsonString CreateDateTimeRfc1123(DateTime ? value) => value is DateTime date ? new JsonString(date.ToString(DateTimeRfc1123Format, CultureInfo.InvariantCulture)) : null;
 
   validateValue(property: Variable): string {
     return ``;

--- a/src/csharp/schema/primitive.ts
+++ b/src/csharp/schema/primitive.ts
@@ -133,6 +133,7 @@ export abstract class Primitive implements EnhancedTypeDeclaration {
 
       case KnownMediaType.Cookie:
       case KnownMediaType.QueryParameter:
+        return toExpression(`if (${value} != null) { queryParameters.Add($"${value}={${value}}"); }`);
       case KnownMediaType.Header:
       case KnownMediaType.Text:
       case KnownMediaType.UriParameter:

--- a/src/csharp/schema/string.ts
+++ b/src/csharp/schema/string.ts
@@ -65,6 +65,7 @@ export class String implements EnhancedTypeDeclaration {
 
       case KnownMediaType.Cookie:
       case KnownMediaType.QueryParameter:
+        return toExpression(`if (!string.IsNullOrEmpty(${value})) { queryParameters.Add($"${value}={System.Uri.EscapeDataString(${value})}"); }`);
       case KnownMediaType.Header:
       case KnownMediaType.Text:
       case KnownMediaType.UriParameter:

--- a/src/remodeler/remodeler.ts
+++ b/src/remodeler/remodeler.ts
@@ -533,6 +533,7 @@ export class Remodeler {
         newPropSchema.extensions = getExtensionProperties(header.instance);
 
         newSchema.properties[propertyName] = new Property(propertyName, {
+          serializedName: header.name || `${each}`,
           description: Interpretations.getDescription(Interpretations.getDescription('', newPropSchema), header.instance),
           schema: newPropSchema,
           extensions: getExtensionProperties(header.instance),


### PR DESCRIPTION
Fixed reading header values.
Cleaned up URI creation and handling of query params.
Added some missing whitespace to various C# key words.
Fixed DateTime formatting preserving trailing zeroes.
Use InvariantCulter when parsing DateTime.